### PR TITLE
New LMR Constants BASE: 1.0 Divisor: 2.0

### DIFF
--- a/src/move_search/search_params.h
+++ b/src/move_search/search_params.h
@@ -5,8 +5,8 @@
 const int RFP_MARGIN = 75;
 const int RFP_MAX_DEPTH = 9;
 
-const double LMR_BASE = 0.8;
-const double LMR_DIVISOR = 2.2;
+const double LMR_BASE = 1.0;
+const double LMR_DIVISOR = 2.0;
 
 const int NMP_MIN_DEPTH = 3;
 


### PR DESCRIPTION
STC: https://engineprogramming.pythonanywhere.com/test/8/

```
ELO   | 7.57 +- 6.08 (95%)
SPRT  | 5.0+0.05s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 10.00]
GAMES | N: 6792 W: 1915 L: 1767 D: 3110
```

Bench: 26029471