### PR TITLE
New LMR Constants BASE: 1.2 Divisor: 1.8

### DIFF
--- a/src/move_search/search_params.h
+++ b/src/move_search/search_params.h
@@ -5,8 +5,8 @@
 const int RFP_MARGIN = 75;
 const int RFP_MAX_DEPTH = 9;
 
-const double LMR_BASE = 1.0;
-const double LMR_DIVISOR = 2.0;
+const double LMR_BASE = 1.2;
+const double LMR_DIVISOR = 1.8;
 
 const int NMP_MIN_DEPTH = 3;
 


### PR DESCRIPTION
https://engineprogramming.pythonanywhere.com/test/13/
```
ELO   | 5.36 +- 4.35 (95%)
SPRT  | 5.0+0.05s Threads=1 Hash=64MB
LLR   | 2.71 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 13352 W: 3752 L: 3546 D: 6054
```

Bench: 21831255