### PR TITLE
Static Exchange Evaluation Pruning in PVS

### DIFF
--- a/src/move_search/pvs.h
+++ b/src/move_search/pvs.h
@@ -168,6 +168,11 @@ int pvs(Position &board, short depth, int ply, int alpha, int beta, bool do_null
 			break;
 		}
 
+		if (!pv_node && depth < SEE_PVS_MIN_DEPTH &&
+			!static_exchange_eval<color>(board, legal_move, legal_move.is_quiet() ? SEE_PVS_QUIET_MARGIN * depth : SEE_PVS_TACTICAL_MARGIN * depth)) {
+			continue;
+		}
+
 		board.play<color>(legal_move);
 		data.nodes_searched += 1;
 		int new_value = NEG_INF_CHESS;

--- a/src/move_search/pvs.h
+++ b/src/move_search/pvs.h
@@ -168,7 +168,7 @@ int pvs(Position &board, short depth, int ply, int alpha, int beta, bool do_null
 			break;
 		}
 
-		if (!pv_node && depth < SEE_PVS_MIN_DEPTH &&
+		if (!pv_node && depth < SEE_PVS_MIN_DEPTH && value > -MATE_BOUND &&
 			!static_exchange_eval<color>(board, legal_move, legal_move.is_quiet() ? SEE_PVS_QUIET_MARGIN * depth : SEE_PVS_TACTICAL_MARGIN * depth)) {
 			continue;
 		}

--- a/src/move_search/search_constants.h
+++ b/src/move_search/search_constants.h
@@ -1,8 +1,8 @@
 #pragma once
-const int POS_INF_CHESS = 1000000;
-const int NEG_INF_CHESS = -POS_INF_CHESS;
-const int MATE_SCORE = POS_INF_CHESS / 10;
-const short MAX_DEPTH = 100;
-const short MAX_PLY = MAX_DEPTH;
-const int MATE_BOUND = MATE_SCORE - MAX_DEPTH;
-const int DEFAULT_SEARCH_TIME = 1000;
+constexpr int POS_INF_CHESS = 1000000;
+constexpr int NEG_INF_CHESS = -POS_INF_CHESS;
+constexpr int MATE_SCORE = POS_INF_CHESS / 10;
+constexpr short MAX_DEPTH = 100;
+constexpr short MAX_PLY = MAX_DEPTH;
+constexpr int MATE_BOUND = MATE_SCORE - MAX_DEPTH;
+constexpr int DEFAULT_SEARCH_TIME = 1000;

--- a/src/move_search/search_params.h
+++ b/src/move_search/search_params.h
@@ -17,3 +17,7 @@ constexpr int ASP_WINDOW_MIN_DEPTH = 6;
 constexpr int ASP_WINDOW_INIT_WINDOW = 12;
 constexpr int ASP_WINDOW_INIT_DELTA = 16;
 constexpr int ASP_WINDOW_FULL_SEARCH_BOUNDS = 3500;
+
+constexpr int SEE_PVS_MIN_DEPTH = 7;
+constexpr int SEE_PVS_QUIET_MARGIN = -50;
+constexpr int SEE_PVS_TACTICAL_MARGIN = -90;


### PR DESCRIPTION
https://engineprogramming.pythonanywhere.com/test/125/
ELO   | 26.39 +- 10.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 1952 W: 557 L: 409 D: 986
