### PR TITLE
Move RFP before NMP beacuse it's cheaper

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -480,3 +480,12 @@ SPRT | 8.0+0.08s Threads=1 Hash=64MB
 LLR | 2.99 (-2.94, 2.94) [0.00, 5.00]
 GAMES | N: 1952 W: 557 L: 409 D: 986
 ```
+
+### Move RFP to before NMP because it's cheaper to prune
+https://engineprogramming.pythonanywhere.com/test/168/
+```
+ELO   | 9.60 +- 6.09 (95%)
+SPRT  | 8.0+0.08s Threads=1 Hash=64MB
+LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
+GAMES | N: 6264 W: 1660 L: 1487 D: 3117
+```

--- a/src/move_search/pvs.h
+++ b/src/move_search/pvs.h
@@ -134,6 +134,12 @@ int pvs(Position &board, short depth, int ply, int alpha, int beta, bool do_null
 		static_eval = evaluate<color>(board);
 	}
 
+	if (!in_check && !pv_node) {
+		if (depth < RFP_MAX_DEPTH && static_eval >= beta + RFP_MARGIN * depth) {
+			return static_eval;
+		}
+	}
+
 	if (depth >= NMP_MIN_DEPTH && !in_check && !pv_node && do_null) {
 		board.play_null<color>();
 
@@ -143,12 +149,6 @@ int pvs(Position &board, short depth, int ply, int alpha, int beta, bool do_null
 
 		board.undo_null<color>();
 		if (null_eval >= beta) return null_eval;
-	}
-
-	if (!in_check && !pv_node) {
-		if (depth < RFP_MAX_DEPTH && static_eval >= beta + RFP_MARGIN * depth) {
-			return static_eval;
-		}
 	}
 
 	MoveList<color, ALL> all_legal_moves(board);


### PR DESCRIPTION
https://engineprogramming.pythonanywhere.com/test/168/
ELO   | 9.60 +- 6.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6264 W: 1660 L: 1487 D: 3117

Bench: 23687290