### PR TITLE
Prefetch TT Entry at search start

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -498,3 +498,12 @@ SPRT  | 8.0+0.08s Threads=1 Hash=64MB
 LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
 GAMES | N: 4984 W: 1421 L: 1252 D: 2311
 ```
+
+### Prefetch Transposition Table Entry
+https://engineprogramming.pythonanywhere.com/test/190/
+```
+ELO   | 10.47 +- 6.48 (95%)
+SPRT  | 8.0+0.08s Threads=1 Hash=64MB
+LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
+GAMES | N: 5744 W: 1581 L: 1408 D: 2755
+```

--- a/src/move_search/pvs.h
+++ b/src/move_search/pvs.h
@@ -22,6 +22,8 @@ bool position_is_draw(Position &board, const int ply);
 template<Color color>
 int q_search(Position &board, const int ply, int alpha, const int beta) {
 
+	t_table.prefetch(board.get_hash());
+
 	if (ply >= MAX_PLY - 2) return evaluate<color>(board);
 
 	if ((data.q_nodes_searched + data.nodes_searched) % 1024 == 0) {
@@ -82,6 +84,9 @@ int q_search(Position &board, const int ply, int alpha, const int beta) {
 
 template<Color color>
 int pvs(Position &board, short depth, int ply, int alpha, int beta, bool do_null) {
+
+	t_table.prefetch(board.get_hash());
+
 	if (ply >= MAX_PLY - 2) return evaluate<color>(board);
 
 	if ((data.q_nodes_searched + data.nodes_searched) % 1024 == 0) {

--- a/src/move_search/tables/transposition_table.cpp
+++ b/src/move_search/tables/transposition_table.cpp
@@ -118,4 +118,8 @@ size_t TranspositionTable::entry_count() {
 	return transposition_table.size();
 }
 
+void TranspositionTable::prefetch(ZobristHash hash) {
+	__builtin_prefetch(&transposition_table[get_index(hash)]);
+}
+
 TranspositionTable t_table = TranspositionTable();

--- a/src/move_search/tables/transposition_table.h
+++ b/src/move_search/tables/transposition_table.h
@@ -32,6 +32,7 @@ public:
 			 TranspositionTableEntryNodeType node_type);
 	void reset_table();
 	void resize(int mb);
+	void prefetch(ZobristHash hash);
 	TranspositionTableSearchResults probe_for_move_ordering(ZobristHash hash);
 	TranspositionTableSearchResults probe_for_search(ZobristHash hash, int depth, int ply);
 	TranspositionTableSearchResults probe_eval(ZobristHash hash, int ply);


### PR DESCRIPTION
https://engineprogramming.pythonanywhere.com/test/190/
ELO   | 10.47 +- 6.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 5744 W: 1581 L: 1408 D: 2755

Bench: 29365174