### PR TITLE
Quiet Late Move Reduction

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -633,3 +633,12 @@ SPRT  | 8.0+0.08s Threads=1 Hash=64MB
 LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
 GAMES | N: 12736 W: 3091 L: 2891 D: 6754
 ```
+
+### Quiet Late Move Reduction
+https://chess.swehosting.se/test/1014/
+```
+ELO   | 6.42 +- 4.65 (95%)
+SPRT  | 8.0+0.08s Threads=1 Hash=64MB
+LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
+GAMES | N: 10224 W: 2539 L: 2350 D: 5335
+```

--- a/src/move_search/reductions.cpp
+++ b/src/move_search/reductions.cpp
@@ -10,8 +10,8 @@
 int lmr_reduction(const bool& pv_node, const int& ply, const bool& in_check, const int& move_idx, const int& depth, const Move& legal_move) {
 	int reduction = 0;
 	int lmr_depth = (pv_node || ply == 0) ? 5 : 3;
-	if (depth >= 3 && move_idx > lmr_depth && legal_move.is_quiet() && !in_check) {
-		reduction = static_cast<int>(lmr_table[depth][move_idx]);
+	if (depth >= 3 && move_idx > lmr_depth && !in_check) {
+		reduction = static_cast<int>(lmr_table[legal_move.is_quiet()][depth][move_idx]);
 		reduction -= pv_node;
 		reduction = std::clamp(reduction, 0, depth - 1);
 	}
@@ -19,6 +19,6 @@ int lmr_reduction(const bool& pv_node, const int& ply, const bool& in_check, con
 }
 
 int nmp_reduction(const int& depth, const int& beta, const int& static_eval) {
-	int reduction = 3 + depth/3 + std::min((static_eval - beta) / 200, 3);
+	int reduction = 3 + depth / 3 + std::min((static_eval - beta) / 200, 3);
 	return std::max(reduction, 3);
 }

--- a/src/move_search/search_params.h
+++ b/src/move_search/search_params.h
@@ -2,16 +2,18 @@
 // Created by Archishmaan Peyyety on 1/1/23.
 //
 #pragma once
-const int RFP_MARGIN = 75;
-const int RFP_MAX_DEPTH = 9;
+constexpr int RFP_MARGIN = 75;
+constexpr int RFP_MAX_DEPTH = 9;
 
-const double LMR_BASE = 1.4;
-const double LMR_DIVISOR = 1.8;
+constexpr double LMR_BASE_CAPTURE = 0.00;
+constexpr double LMR_DIVISOR_CAPTURE = 3.25;
+constexpr double LMR_BASE_QUIET = 1.50;
+constexpr double LMR_DIVISOR_QUIET = 1.75;
 
-const int NMP_MIN_DEPTH = 3;
+constexpr int NMP_MIN_DEPTH = 3;
 
-const int LMP_MIN_DEPTH = 3;
-const int LMP_DEPTH_MULTIPLIER = 12;
+constexpr int LMP_MIN_DEPTH = 3;
+constexpr int LMP_DEPTH_MULTIPLIER = 12;
 
 constexpr int Q_SEARCH_FUTILITY_MARGIN = 60;
 

--- a/src/move_search/tables/lmr_table.cpp
+++ b/src/move_search/tables/lmr_table.cpp
@@ -5,12 +5,13 @@
 #include <cmath>
 #include "lmr_table.h"
 
-double lmr_table[MAX_DEPTH + 1][MAX_DEPTH + 1];
+double lmr_table[2][MAX_DEPTH + 1][MAX_DEPTH + 1];
 
 void init_lmr_table() {
 	for (int depth = 0; depth < MAX_DEPTH; depth++) {
 		for (int move_idx = 0; move_idx < MAX_DEPTH; move_idx++) {
-			lmr_table[depth][move_idx] = LMR_BASE + log(depth) * log(move_idx) / LMR_DIVISOR;
+			lmr_table[0][depth][move_idx] = LMR_BASE_CAPTURE + log(depth) * log(move_idx) / LMR_DIVISOR_CAPTURE;
+			lmr_table[1][depth][move_idx] = LMR_BASE_QUIET + log(depth) * log(move_idx) / LMR_DIVISOR_QUIET;
 		}
 	}
 }

--- a/src/move_search/tables/lmr_table.h
+++ b/src/move_search/tables/lmr_table.h
@@ -2,5 +2,5 @@
 #include "../search_constants.h"
 #include "../search_params.h"
 
-extern double lmr_table[MAX_DEPTH + 1][MAX_DEPTH + 1];
+extern double lmr_table[2][MAX_DEPTH + 1][MAX_DEPTH + 1];
 extern void init_lmr_table();


### PR DESCRIPTION
https://chess.swehosting.se/test/1014/
ELO   | 6.42 +- 4.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 10224 W: 2539 L: 2350 D: 5335

Bench: 16713183