### PR TITLE
New LMR Constants

### DIFF
--- a/src/move_search/search_params.h
+++ b/src/move_search/search_params.h
@@ -5,8 +5,8 @@
 constexpr int RFP_MARGIN = 75;
 constexpr int RFP_MAX_DEPTH = 9;
 
-constexpr double LMR_BASE_CAPTURE = 0.00;
-constexpr double LMR_DIVISOR_CAPTURE = 3.25;
+constexpr double LMR_BASE_CAPTURE = 1.40;
+constexpr double LMR_DIVISOR_CAPTURE = 1.80;
 constexpr double LMR_BASE_QUIET = 1.50;
 constexpr double LMR_DIVISOR_QUIET = 1.75;
 


### PR DESCRIPTION
https://chess.swehosting.se/test/1020/
ELO   | 4.52 +- 3.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 17456 W: 4234 L: 4007 D: 9215

Bench: 14224928