### PR TITLE
Bug fix MTG time allocation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -669,3 +669,11 @@ SPRT  | 8.0+0.08s Threads=1 Hash=64MB
 LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
 GAMES | N: 17640 W: 4137 L: 3914 D: 9589
 ```
+
+### Bug fix MTG Time Allocation
+https://chess.swehosting.se/test/1552/
+```
+ELO   | 91.34 +- 5.13 (95%)
+CONF  | 40/4.0+0.00s Threads=1 Hash=64MB
+GAMES | N: 10000 W: 4075 L: 1505 D: 4420
+```

--- a/src/uci_interpreter/time_manager.cpp
+++ b/src/uci_interpreter/time_manager.cpp
@@ -24,8 +24,8 @@ TimeBounds allocate_time_moves_to_go(int time_remaining, int moves_to_go) {
 	int optimum = static_cast<int>(std::min(scale * time_remaining, eight));
 
 	TimeBounds bounds{};
-	bounds.first = static_cast<int>(std::min(5.0 * optimum, eight));
-	bounds.second = optimum;
+	bounds.second = static_cast<int>(std::min(5.0 * optimum, eight));
+	bounds.first = optimum;
 	return bounds;
 }
 


### PR DESCRIPTION
https://chess.swehosting.se/test/1552/
ELO   | 91.34 +- 5.13 (95%)
CONF  | 40/4.0+0.00s Threads=1 Hash=64MB
GAMES | N: 10000 W: 4075 L: 1505 D: 4420

Bench: 13974136