### PR TITLE
Use nodes spent to scale soft time bounds

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -677,3 +677,29 @@ ELO   | 91.34 +- 5.13 (95%)
 CONF  | 40/4.0+0.00s Threads=1 Hash=64MB
 GAMES | N: 10000 W: 4075 L: 1505 D: 4420
 ```
+
+### Use nodes spent to scale soft time bounds
+#### STC
+https://chess.swehosting.se/test/1595/
+```
+ELO   | 11.99 +- 7.03 (95%)
+SPRT  | 8.0+0.08s Threads=1 Hash=64MB
+LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
+GAMES | N: 4696 W: 1258 L: 1096 D: 2342
+```
+#### LTC
+https://chess.swehosting.se/test/1597/
+```
+ELO   | 16.79 +- 7.94 (95%)
+SPRT  | 40.0+0.40s Threads=1 Hash=128MB
+LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
+GAMES | N: 2920 W: 651 L: 510 D: 1759
+```
+#### MTG
+https://chess.swehosting.se/test/1596/
+```
+ELO   | 30.08 +- 12.20 (95%)
+SPRT  | 40/4.0+0.00s Threads=1 Hash=64MB
+LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
+GAMES | N: 1760 W: 570 L: 418 D: 772
+```

--- a/src/move_search/pvs.cpp
+++ b/src/move_search/pvs.cpp
@@ -7,8 +7,6 @@
 PVSData data;
 
 void reset_data() {
-	data.nodes_searched = 0;
-	data.q_nodes_searched = 0;
 	data.search_completed = true;
 	data.seldepth = 0;
 	std::memset(data.pv.table, 0, sizeof(data.pv.table));

--- a/src/move_search/search.cpp
+++ b/src/move_search/search.cpp
@@ -3,14 +3,14 @@
 //
 #include "search.h"
 #include <iostream>
-#include "../utils/clock.h"
+#include <algorithm>
 
 void update_best_move_results(BestMoveSearchResults& search_results, PVSData& ab_results, int sub_depth, bool debug) {
 	std::memset(search_results.pv, 0, sizeof(search_results.pv));
 	search_results.value = ab_results.value;
 	search_results.best_move = ab_results.best_move;
 	search_results.depth_searched = sub_depth;
-	search_results.nodes_searched += ab_results.nodes_searched + ab_results.q_nodes_searched;
+	search_results.nodes_searched += ab_results.nodes_searched;
 	search_results.seldepth = ab_results.seldepth;
 	search_results.time_searched = get_elapsed_time(TimeResolution::Milliseconds);
 	for (int i = 0; i < ab_results.pv.length[0]; i++) {
@@ -21,4 +21,13 @@ void update_best_move_results(BestMoveSearchResults& search_results, PVSData& ab
 					<<  " score cp " << search_results.value << " time " << search_results.time_searched
 					<< " nodes " << search_results.nodes_searched << " pv " << search_results.pv << std::endl;
 	}
+}
+
+double scale_soft_time_limit(BestMoveSearchParameters &params, PVSData& ab_results, int depth) {
+	if (params.soft_time_limit == params.hard_time_limit && params.soft_time_limit == 86'400'000) return 1.00;
+	if (depth <= 7) return 1.00;
+
+	Move best_move = ab_results.best_move;
+	double percent_nodes_spent = static_cast<double>(ab_results.nodes_spend[best_move.from()][best_move.to()]) / static_cast<double>(data.nodes_searched);
+	return (1.5 - percent_nodes_spent) * 1.35;
 }

--- a/src/move_search/types.h
+++ b/src/move_search/types.h
@@ -43,11 +43,11 @@ struct PVSData {
 	// triangular-table-table
 	PV pv{};
 	uint64_t nodes_searched{};
-	uint64_t q_nodes_searched{};
 	int seldepth{};
 
 	Move moves_made[MAX_PLY];
 	int time_limit{};
 
 	Move excluded_moves[MAX_PLY]{};
+	uint64_t nodes_spend[NSQUARES][NSQUARES]{};
 };


### PR DESCRIPTION
STC
https://chess.swehosting.se/test/1595/
ELO   | 11.99 +- 7.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4696 W: 1258 L: 1096 D: 2342

LTC
https://chess.swehosting.se/test/1597/
ELO   | 16.79 +- 7.94 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 2920 W: 651 L: 510 D: 1759

MTG
https://chess.swehosting.se/test/1596/
ELO   | 30.08 +- 12.20 (95%)
SPRT  | 40/4.0+0.00s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 1760 W: 570 L: 418 D: 772

Bench: 38658775